### PR TITLE
Reference correct configuration data in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ java -jar target/*.jar
 ```
 
 It will start up on port 8888 and serve configuration data from
-"https://github.com/spring-cloud-samples/config-repo":
+"https://github.com/steeltoeoss/config-repo":
 
 ## Resources
 


### PR DESCRIPTION
- application.yml references <https://github.com/steeltoeoss/config-repo> not "https://github.com/spring-cloud-samples/config-repo" and readme should reflect that

Found this through link on [tutorial](https://github.com/SteeltoeOSS/Tutorials/blob/master/getting-started-local.md)